### PR TITLE
Register otclient scheme with CEF

### DIFF
--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -313,7 +313,9 @@ std::string ResourceManager::resolvePath(const std::string& path)
     if(stdext::starts_with(path, "/"))
         fullPath = path;
     else {
-        std::string scriptPath = "/" + g_lua.getCurrentSourcePath();
+        std::string scriptPath;
+        if(g_lua.isInCppCallback())
+            scriptPath = "/" + g_lua.getCurrentSourcePath();
         if(!scriptPath.empty())
             fullPath += scriptPath + "/";
         fullPath += path;

--- a/src/framework/ui/cefphysfsresourcehandler.cpp
+++ b/src/framework/ui/cefphysfsresourcehandler.cpp
@@ -77,17 +77,15 @@ static std::string resolvePathFromUrl(const std::string& url) {
     const std::string httpsHost = "https://otclient";
 
     std::string path;
-    if (url.rfind(scheme, 0) == 0) {
+    if (url.rfind(scheme, 0) == 0)
         path = url.substr(scheme.size());
-    } else if (url.rfind(httpHost, 0) == 0) {
+    else if (url.rfind(httpHost, 0) == 0)
         path = url.substr(httpHost.size());
-        if (!path.empty() && path[0] == '/')
-            path.erase(0, 1);
-    } else if (url.rfind(httpsHost, 0) == 0) {
+    else if (url.rfind(httpsHost, 0) == 0)
         path = url.substr(httpsHost.size());
-        if (!path.empty() && path[0] == '/')
-            path.erase(0, 1);
-    }
+
+    if (!path.empty() && path[0] != '/')
+        path.insert(path.begin(), '/');
     return path;
 }
 

--- a/src/framework/ui/uiwebview.h
+++ b/src/framework/ui/uiwebview.h
@@ -63,7 +63,9 @@ public:
     bool isLoading();
     
     // JavaScript bridge
-    void registerJavaScriptCallback(const std::string& name, const std::function<void(const std::string&)>& callback);
+    void registerJavaScriptCallback(const std::string& name,
+                                    const std::function<void(const std::string&)>& callback,
+                                    int luaRef = -1);
     void unregisterJavaScriptCallback(const std::string& name);
     
     // Events
@@ -110,7 +112,11 @@ private:
     bool m_scrollable;
     bool m_loading;
     
-    std::map<std::string, std::function<void(const std::string&)>> m_jsCallbacks;
+    struct JSCallback {
+        std::function<void(const std::string&)> callback;
+        int luaRef;
+    };
+    std::map<std::string, JSCallback> m_jsCallbacks;
     
     void updateWebViewSize();
     void initializeWebView();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include "include/cef_browser.h"
 #include "include/cef_command_line.h"
 #include "include/cef_render_process_handler.h"
+#include "include/cef_scheme.h"
 #include "include/wrapper/cef_helpers.h"
 #include "include/wrapper/cef_message_router.h"
 #include <unistd.h>
@@ -53,6 +54,13 @@ bool g_cefInitialized = false;
 class OTClientCEFApp : public CefApp, public CefRenderProcessHandler {
 public:
     OTClientCEFApp() {}
+
+    void OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar) override {
+        registrar->AddCustomScheme("otclient",
+                                   CEF_SCHEME_OPTION_STANDARD |
+                                   CEF_SCHEME_OPTION_LOCAL |
+                                   CEF_SCHEME_OPTION_DISPLAY_ISOLATED);
+    }
 
     CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override { return this; }
 

--- a/webviews/demo/demo.html
+++ b/webviews/demo/demo.html
@@ -4,8 +4,8 @@
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="demo.css">
         <link rel="stylesheet" type="text/css" href="../shared/otclient.css">
-        <script type="text/javascript" src="demo.js"></script>
         <script type="text/javascript" src="../shared/otclient.js"></script>
+        <script type="text/javascript" src="demo.js"></script>
     </head>
     <body>
       <div class="container">

--- a/webviews/shared/otclient.js
+++ b/webviews/shared/otclient.js
@@ -1,0 +1,13 @@
+function sendToLua(name, data) {
+  if (typeof luaCallback !== 'function') {
+    return;
+  }
+
+  luaCallback({
+    request: JSON.stringify({ name, data }),
+    onSuccess: () => {},
+    onFailure: (code, msg) => console.error(msg),
+  });
+}
+
+sendToLua('js_loaded');


### PR DESCRIPTION
## Summary
- Register custom `otclient` scheme with CEF and mark it as standard/local
- Include CEF scheme header for scheme registration
- Wrap `luaCallback` usage in JS to pass the expected object and signal script load
- Expose `sendToLua` helper that calls the injected bridge with a single object
- Keep Lua callbacks alive by storing strong references and cleaning them up on unregister
- Bind `registerJavaScriptCallback` manually to capture Lua callback references
- Clean up Lua stack after registering callbacks to prevent stack-size assertions
- Avoid Lua stack access in resource manager when not called from Lua to prevent crashes

## Testing
- `mkdir -p build && cd build && cmake .. -DUSE_CEF=ON && make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_688f9966f55083279a7ec2c51f373729