### PR TITLE
Fix Windows build by removing GLES2 header and gating GPU renderer

### DIFF
--- a/src/cef/CMakeLists.txt
+++ b/src/cef/CMakeLists.txt
@@ -33,10 +33,10 @@ set(cef_SOURCES
     $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Linux>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/cef_renderergpulinuxnonmesa.h>
     $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Linux>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/linuxgpucontext.cpp>
     $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Linux>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/linuxgpucontext.h>
-    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/cef_renderergpuwin.cpp>
-    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/cef_renderergpuwin.h>
-    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/windowsgpucontext.cpp>
-    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/windowsgpucontext.h>
+    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>,$<STREQUAL:${OPENGLES},2.0>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/cef_renderergpuwin.cpp>
+    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>,$<STREQUAL:${OPENGLES},2.0>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/cef_renderergpuwin.h>
+    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>,$<STREQUAL:${OPENGLES},2.0>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/windowsgpucontext.cpp>
+    $<$<AND:$<BOOL:${USE_CEF}>,$<PLATFORM_ID:Windows>,$<STREQUAL:${OPENGLES},2.0>>:${CMAKE_CURRENT_LIST_DIR}/graphics/gpu/windowsgpucontext.h>
     $<$<BOOL:${USE_CEF}>:${CMAKE_CURRENT_LIST_DIR}/resources/cefphysfsresourcehandler.cpp>
     $<$<BOOL:${USE_CEF}>:${CMAKE_CURRENT_LIST_DIR}/resources/cefphysfsresourcehandler.h>
 )

--- a/src/cef/core/cef_config.cpp
+++ b/src/cef/core/cef_config.cpp
@@ -65,6 +65,16 @@ void CefConfig::applyGenericCommandLineFlags(CefRefPtr<CefCommandLine> command_l
     command_line->AppendSwitch("disable-features=PushMessaging,BackgroundSync,GCM");
 }
 
+CefBrowserSettings CefConfig::createBrowserSettings() {
+    CefBrowserSettings settings;
+    applyBrowserSettings(settings);
+    return settings;
+}
+
+void CefConfig::applyBrowserSettings(CefBrowserSettings& settings) {
+    (void)settings;
+}
+
 
 
 // ============================================================================

--- a/src/cef/core/cef_config.h
+++ b/src/cef/core/cef_config.h
@@ -68,6 +68,9 @@ public:
     virtual void setUserPreference(const std::string& key, const std::string& value) {}
     virtual std::string getUserPreference(const std::string& key) const { return ""; }
 
+    // Shared texture usage (GPU-only features)
+    virtual bool shouldUseSharedTexture() const { return false; }
+
     // Create browser settings with platform-specific defaults
     CefBrowserSettings createBrowserSettings();
 

--- a/src/cef/core/cef_config.h
+++ b/src/cef/core/cef_config.h
@@ -5,6 +5,7 @@
 #include "include/cef_app.h"
 #include "include/cef_command_line.h"
 #include "include/cef_base.h"
+#include "include/cef_browser.h"
 #include <memory>
 #include <string>
 
@@ -67,13 +68,17 @@ public:
     virtual void setUserPreference(const std::string& key, const std::string& value) {}
     virtual std::string getUserPreference(const std::string& key) const { return ""; }
 
+    // Create browser settings with platform-specific defaults
+    CefBrowserSettings createBrowserSettings();
+
 protected:
     GenericSettings m_genericSettings;
     GenericCommandLineFlags m_genericFlags;
-    
+
     // Helper to apply generic settings
     void applyGenericSettings(CefSettings& settings);
     void applyGenericCommandLineFlags(CefRefPtr<CefCommandLine> command_line);
+    virtual void applyBrowserSettings(CefBrowserSettings& settings);
 };
 
 // Platform-specific configurations are defined in separate files:

--- a/src/cef/core/cef_confwin.cpp
+++ b/src/cef/core/cef_confwin.cpp
@@ -29,23 +29,26 @@ std::wstring CefConfigWindows::getExecutableDirectory() const {
     return (pos == std::wstring::npos) ? L"." : p.substr(0, pos);
 }
 
+void CefConfigWindows::setupDllDirectories() const {
+    const std::wstring cefDir = getExecutableDirectory() + L"\\cef";
+    SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
+    AddDllDirectory(cefDir.c_str());
+}
+
 void CefConfigWindows::configurePaths(CefSettings& settings) {
+    setupDllDirectories();
     const std::wstring exeDir = getExecutableDirectory();
     const std::wstring cefDir = exeDir + L"\\cef";
     const std::wstring localesDir = cefDir + L"\\locales";
     const std::wstring cacheDir = cefDir + L"\\cache";
     const std::wstring subprocessPath = cefDir + L"\\otclient_cef_subproc.exe";
 
-    // Setup libcef.dll delay-loaded
-    SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
-    AddDllDirectory(cefDir.c_str());
-
     CefString(&settings.resources_dir_path) = cefDir;
     CefString(&settings.locales_dir_path) = localesDir;
     CefString(&settings.cache_path) = cacheDir;
     CefString(&settings.root_cache_path) = cacheDir;
     CefString(&settings.browser_subprocess_path) = subprocessPath;
-    
+
     logMessage("Windows", stdext::format("CEF directory: %s", std::string(cefDir.begin(), cefDir.end())).c_str());
 }
 
@@ -78,6 +81,7 @@ CefMainArgs CefConfigWindows::createMainArgs(int argc, const char* argv[]) {
 }
 
 bool CefConfigWindows::handleSubprocessExecution(const CefMainArgs& args, CefRefPtr<CefApp> app) {
+    setupDllDirectories();
     // Early-subprocess exit (the main executable should never be used as subprocess
     // when browser_subprocess_path is defined, but call CefExecuteProcess for completeness)
     const int code = CefExecuteProcess(args, nullptr, nullptr);

--- a/src/cef/core/cef_confwin.cpp
+++ b/src/cef/core/cef_confwin.cpp
@@ -81,10 +81,6 @@ void CefConfigWindows::applySettings(CefSettings& settings) {
 void CefConfigWindows::applyCommandLineFlags(CefRefPtr<CefCommandLine> command_line) {
 #if defined(OPENGL_ES) && OPENGL_ES == 2
     configureAngle(command_line);
-#else
-    command_line->AppendSwitch("disable-gpu");
-    command_line->AppendSwitch("disable-gpu-compositing");
-    command_line->AppendSwitch("disable-gpu-rasterization");
 #endif
     applyGenericCommandLineFlags(command_line);
 

--- a/src/cef/core/cef_confwin.cpp
+++ b/src/cef/core/cef_confwin.cpp
@@ -20,6 +20,16 @@
 
 namespace cef {
 
+CefConfigWindows::CefConfigWindows() {
+#if !defined(OPENGL_ES) || OPENGL_ES != 2
+    m_genericFlags.enable_gpu = false;
+    m_genericFlags.enable_gpu_compositing = false;
+    m_genericFlags.enable_gpu_rasterization = false;
+    m_genericFlags.disable_software_rasterizer = false;
+    m_genericFlags.disable_gpu_sandbox = false;
+#endif
+}
+
 std::wstring CefConfigWindows::getExecutableDirectory() const {
     wchar_t buf[MAX_PATH];
     DWORD n = GetModuleFileNameW(nullptr, buf, MAX_PATH);
@@ -69,10 +79,16 @@ void CefConfigWindows::applySettings(CefSettings& settings) {
 }
 
 void CefConfigWindows::applyCommandLineFlags(CefRefPtr<CefCommandLine> command_line) {
+#if defined(OPENGL_ES) && OPENGL_ES == 2
     configureAngle(command_line);
+#else
+    command_line->AppendSwitch("disable-gpu");
+    command_line->AppendSwitch("disable-gpu-compositing");
+    command_line->AppendSwitch("disable-gpu-rasterization");
+#endif
     applyGenericCommandLineFlags(command_line);
-    
-    logMessage("Windows", stdext::format("Command line flags: %s", 
+
+    logMessage("Windows", stdext::format("Command line flags: %s",
         command_line->GetCommandLineString().ToString()).c_str());
 }
 

--- a/src/cef/core/cef_confwin.cpp
+++ b/src/cef/core/cef_confwin.cpp
@@ -121,6 +121,14 @@ void CefConfigWindows::registerSchemeHandlers() {
 #endif
 }
 
+bool CefConfigWindows::shouldUseSharedTexture() const {
+#if defined(OPENGL_ES) && OPENGL_ES == 2
+    return true;
+#else
+    return false;
+#endif
+}
+
 } // namespace cef
 
 #endif // _WIN32

--- a/src/cef/core/cef_confwin.h
+++ b/src/cef/core/cef_confwin.h
@@ -11,6 +11,7 @@ namespace cef {
 // Windows-specific CEF configuration
 class CefConfigWindows : public CefConfig {
 public:
+    CefConfigWindows();
     void applySettings(CefSettings& settings) override;
     void applyCommandLineFlags(CefRefPtr<CefCommandLine> command_line) override;
     void configurePaths(CefSettings& settings) override;

--- a/src/cef/core/cef_confwin.h
+++ b/src/cef/core/cef_confwin.h
@@ -22,6 +22,7 @@ public:
 private:
     std::wstring getExecutableDirectory() const;
     void configureAngle(CefRefPtr<CefCommandLine> command_line);
+    void setupDllDirectories() const;
 };
 
 } // namespace cef

--- a/src/cef/core/cef_confwin.h
+++ b/src/cef/core/cef_confwin.h
@@ -18,6 +18,7 @@ public:
     CefMainArgs createMainArgs(int argc, const char* argv[]) override;
     bool handleSubprocessExecution(const CefMainArgs& args, CefRefPtr<CefApp> app) override;
     void registerSchemeHandlers() override;
+    bool shouldUseSharedTexture() const override;
     std::string getPlatformName() const override { return "Windows"; }
 
 private:

--- a/src/cef/core/cef_init.cpp
+++ b/src/cef/core/cef_init.cpp
@@ -6,9 +6,11 @@
 #include <framework/stdext/format.h>
 #include "include/cef_app.h"
 #include <exception>
+#include <memory>
 
 // Global CEF state
 bool g_cefInitialized = false;
+std::unique_ptr<cef::CefConfig> g_cefConfig;
 
 /**
  * Initialize CEF with platform-specific configuration
@@ -25,27 +27,27 @@ bool g_cefInitialized = false;
  */
 bool InitializeCEF(int argc, const char* argv[]) {
     // Create platform-specific configuration
-    auto config = cef::CefConfigFactory::createConfig();
-    if (!config) {
+    g_cefConfig = cef::CefConfigFactory::createConfig();
+    if (!g_cefConfig) {
         cef::logMessage("ERROR", "Failed to create CEF configuration!");
         return false;
     }
 
-    cef::logMessage(config->getPlatformName().c_str(), "Starting CEF initialization");
+    cef::logMessage(g_cefConfig->getPlatformName().c_str(), "Starting CEF initialization");
 
     try {
         // Create CEF app and main args using platform-specific config
         CefRefPtr<CefApp> app = new OTClientBrowserApp();
-        CefMainArgs main_args = config->createMainArgs(argc, argv);
-        
+        CefMainArgs main_args = g_cefConfig->createMainArgs(argc, argv);
+
         // Handle subprocess execution (platform-specific, may exit)
-        config->handleSubprocessExecution(main_args, app);
-        
+        g_cefConfig->handleSubprocessExecution(main_args, app);
+
         // Configure CEF settings and initialize
         CefSettings settings;
-        config->applySettings(settings);
-        
-        cef::logMessage(config->getPlatformName().c_str(), "Initializing CEF with configured settings");
+        g_cefConfig->applySettings(settings);
+
+        cef::logMessage(g_cefConfig->getPlatformName().c_str(), "Initializing CEF with configured settings");
         bool result = CefInitialize(main_args, settings, app, nullptr);
         
         if (!result) {
@@ -54,10 +56,10 @@ bool InitializeCEF(int argc, const char* argv[]) {
         }
 
         // Register custom scheme handlers
-        config->registerSchemeHandlers();
-        
+        g_cefConfig->registerSchemeHandlers();
+
         g_cefInitialized = true;
-        cef::logMessage(config->getPlatformName().c_str(), "CEF initialization completed successfully");
+        cef::logMessage(g_cefConfig->getPlatformName().c_str(), "CEF initialization completed successfully");
         
         return true;
         
@@ -94,13 +96,16 @@ void ShutdownCEF() {
         CefShutdown();
         
         g_cefInitialized = false;
+        g_cefConfig.reset();
         cef::logMessage("CEF", "CEF shutdown completed successfully");
         
     } catch (const std::exception& e) {
         cef::logMessage("ERROR", stdext::format("CEF shutdown failed with exception: %s", e.what()).c_str());
         g_cefInitialized = false; // Reset state even on error
+        g_cefConfig.reset();
     } catch (...) {
         cef::logMessage("ERROR", "CEF shutdown failed with unknown exception");
         g_cefInitialized = false; // Reset state even on error
+        g_cefConfig.reset();
     }
 }

--- a/src/cef/core/cef_init.h
+++ b/src/cef/core/cef_init.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #ifdef USE_CEF
+#include <memory>
 bool InitializeCEF(int argc, const char* argv[]);
 void ShutdownCEF();
 extern bool g_cefInitialized;
+namespace cef { class CefConfig; }
+extern std::unique_ptr<cef::CefConfig> g_cefConfig;
 #else
 inline bool InitializeCEF(int, const char**) { return true; }
 inline void ShutdownCEF() {}

--- a/src/cef/graphics/cef_renderer.cpp
+++ b/src/cef/graphics/cef_renderer.cpp
@@ -2,6 +2,9 @@
 #include "../ui/uicefwebview.h"
 #include <framework/graphics/graphics.h>
 #include <framework/graphics/texture.h>
+#ifdef USE_CEF
+#include "include/cef_browser.h"
+#endif
 
 void CefRenderer::draw(Fw::DrawPane drawPane)
 {
@@ -12,3 +15,10 @@ void CefRenderer::draw(Fw::DrawPane drawPane)
     }
     (void)drawPane;
 }
+
+#ifdef USE_CEF
+void CefRenderer::onRenderSupported(CefWindowInfo& windowInfo) const
+{
+    windowInfo.shared_texture_enabled = false;
+}
+#endif

--- a/src/cef/graphics/cef_renderer.h
+++ b/src/cef/graphics/cef_renderer.h
@@ -4,6 +4,7 @@
 
 #ifdef USE_CEF
 #include "include/cef_render_handler.h"
+#include "include/cef_window_info.h"
 #endif
 
 class UICEFWebView;
@@ -18,6 +19,10 @@ public:
     virtual void onPaint(const void* buffer, int width, int height,
                          const CefRenderHandler::RectList& dirtyRects) = 0;
     virtual void onAcceleratedPaint(const CefAcceleratedPaintInfo& info) = 0;
+    virtual void onRenderSupported(CefWindowInfo& windowInfo) const
+    {
+        windowInfo.shared_texture_enabled = false;
+    }
 #endif
     virtual void draw(Fw::DrawPane drawPane);
     virtual bool isSupported() const { return true; }

--- a/src/cef/graphics/cef_renderer.h
+++ b/src/cef/graphics/cef_renderer.h
@@ -4,7 +4,7 @@
 
 #ifdef USE_CEF
 #include "include/cef_render_handler.h"
-#include "include/cef_window_info.h"
+struct CefWindowInfo;
 #endif
 
 class UICEFWebView;
@@ -19,10 +19,7 @@ public:
     virtual void onPaint(const void* buffer, int width, int height,
                          const CefRenderHandler::RectList& dirtyRects) = 0;
     virtual void onAcceleratedPaint(const CefAcceleratedPaintInfo& info) = 0;
-    virtual void onRenderSupported(CefWindowInfo& windowInfo) const
-    {
-        windowInfo.shared_texture_enabled = false;
-    }
+    virtual void onRenderSupported(CefWindowInfo& windowInfo) const;
 #endif
     virtual void draw(Fw::DrawPane drawPane);
     virtual bool isSupported() const { return true; }

--- a/src/cef/graphics/cef_rendererfactory.cpp
+++ b/src/cef/graphics/cef_rendererfactory.cpp
@@ -1,13 +1,17 @@
 #include "cef_rendererfactory.h"
 #include "cef_renderercpu.h"
+#if defined(__linux__)
 #include "gpu/cef_renderergpulinuxmesa.h"
 #include "gpu/cef_renderergpulinuxnonmesa.h"
+#endif
+#if defined(_WIN32) && defined(OPENGL_ES) && OPENGL_ES == 2
 #include "gpu/cef_renderergpuwin.h"
+#endif
 
 std::unique_ptr<CefRenderer> CefRendererFactory::createRenderer(UICEFWebView& view)
 {
 #if defined(USE_CEF)
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(OPENGL_ES) && OPENGL_ES == 2
     {
         auto renderer = std::make_unique<CefRendererGPUWin>(view);
         if(renderer->isSupported())

--- a/src/cef/graphics/gpu/cef_renderergpuwin.cpp
+++ b/src/cef/graphics/gpu/cef_renderergpuwin.cpp
@@ -5,7 +5,6 @@
 #if defined(USE_CEF) && defined(_WIN32)
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
-#include <GLES2/gl2ext.h>
 #include <d3d11.h>
 #include <dxgi.h>
 #endif
@@ -93,7 +92,7 @@ void CefRendererGPUWin::onAcceleratedPaint(const CefAcceleratedPaintInfo& info)
 
 bool CefRendererGPUWin::isSupported() const
 {
-#if defined(USE_CEF) && defined(_WIN32)
+#if defined(USE_CEF) && defined(_WIN32) && defined(OPENGL_ES) && OPENGL_ES == 2
     return true;
 #else
     return false;

--- a/src/cef/graphics/gpu/cef_renderergpuwin.cpp
+++ b/src/cef/graphics/gpu/cef_renderergpuwin.cpp
@@ -3,6 +3,9 @@
 #include <framework/core/logger.h>
 #include <framework/graphics/graphics.h>
 #include "../../core/cef_init.h"
+#if defined(USE_CEF)
+#include <include/cef_browser.h>
+#endif
 #if defined(USE_CEF) && defined(_WIN32)
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/src/cef/graphics/gpu/cef_renderergpuwin.cpp
+++ b/src/cef/graphics/gpu/cef_renderergpuwin.cpp
@@ -2,6 +2,7 @@
 #include "../../ui/uicefwebview.h"
 #include <framework/core/logger.h>
 #include <framework/graphics/graphics.h>
+#include "../../core/cef_init.h"
 #if defined(USE_CEF) && defined(_WIN32)
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -97,5 +98,11 @@ bool CefRendererGPUWin::isSupported() const
 #else
     return false;
 #endif
+}
+
+void CefRendererGPUWin::onRenderSupported(CefWindowInfo& windowInfo) const
+{
+    if(g_cefConfig && g_cefConfig->shouldUseSharedTexture())
+        windowInfo.shared_texture_enabled = true;
 }
 

--- a/src/cef/graphics/gpu/cef_renderergpuwin.h
+++ b/src/cef/graphics/gpu/cef_renderergpuwin.h
@@ -11,6 +11,7 @@ public:
                  const CefRenderHandler::RectList& dirtyRects) override;
     void onAcceleratedPaint(const CefAcceleratedPaintInfo& info) override;
     bool isSupported() const override;
+    void onRenderSupported(CefWindowInfo& windowInfo) const override;
 
 private:
     int m_lastWidth;

--- a/src/cef/ui/uicefwebview.cpp
+++ b/src/cef/ui/uicefwebview.cpp
@@ -317,12 +317,10 @@ void UICEFWebView::createWebView()
     CefWindowInfo window_info;
     window_info.SetAsWindowless(0); // 0 = no parent window
    
-    // Enable shared textures only when GPU acceleration is available
-#if defined(_WIN32) && defined(OPENGL_ES) && OPENGL_ES == 2
-    window_info.shared_texture_enabled = true;
-#else
-    window_info.shared_texture_enabled = false;
-#endif
+    if(m_renderer)
+        m_renderer->onRenderSupported(window_info);
+    else
+        window_info.shared_texture_enabled = false;
     // window_info.external_begin_frame_enabled = true; // Not needed with multi_threaded_message_loop = true
 
     g_logger.info("UICEFWebView: Window info configured for off-screen rendering");

--- a/src/cef/ui/uicefwebview.cpp
+++ b/src/cef/ui/uicefwebview.cpp
@@ -37,6 +37,7 @@
 
 #ifdef USE_CEF
 #include "../graphics/cef_renderer.h"
+#include <include/cef_browser.h>
 #include <include/cef_frame.h>
 #include "include/cef_parser.h"
 #endif

--- a/src/cef/ui/uicefwebview.cpp
+++ b/src/cef/ui/uicefwebview.cpp
@@ -26,6 +26,8 @@
 #include <framework/core/resourcemanager.h>
 #include <framework/luaengine/luainterface.h>
 #include "../graphics/cef_rendererfactory.h"
+#include <cef/core/cef_config.h>
+#include <cef/core/cef_init.h>
 #include "cef_client.h"
 #include "cef_inputhandler.h"
 #include <string>
@@ -56,8 +58,6 @@ static std::string escape(const std::string& str) {
     return result;
 }
 
-// Global flag to check if CEF was initialized
-extern bool g_cefInitialized;
 
 // Static member initialization
 std::vector<UICEFWebView*> UICEFWebView::s_activeWebViews;
@@ -305,7 +305,7 @@ void UICEFWebView::createWebView()
     g_logger.info("UICEFWebView: Client created successfully");
 
     // Browser settings
-    CefBrowserSettings browser_settings;
+    CefBrowserSettings browser_settings = g_cefConfig ? g_cefConfig->createBrowserSettings() : CefBrowserSettings();
     g_logger.info("UICEFWebView: Browser settings configured");
 
     int maxFps = g_app.getForegroundPaneMaxFps();
@@ -317,7 +317,12 @@ void UICEFWebView::createWebView()
     CefWindowInfo window_info;
     window_info.SetAsWindowless(0); // 0 = no parent window
    
+    // Enable shared textures only when GPU acceleration is available
+#if defined(_WIN32) && defined(OPENGL_ES) && OPENGL_ES == 2
     window_info.shared_texture_enabled = true;
+#else
+    window_info.shared_texture_enabled = false;
+#endif
     // window_info.external_begin_frame_enabled = true; // Not needed with multi_threaded_message_loop = true
 
     g_logger.info("UICEFWebView: Window info configured for off-screen rendering");


### PR DESCRIPTION
## Summary
- remove conflicting `<GLES2/gl2ext.h>` include from Windows GPU renderer
- skip Windows GPU renderer when building without OpenGL ES 2

## Testing
- ⚠️ `./pre-build.sh` (build interrupted at ~12%)

------
https://chatgpt.com/codex/tasks/task_e_68acd45437bc83278bd0408773ee7d45